### PR TITLE
Use Mac address as Authorisation: Bearer and also to retrieve Friendly ID for Claim your device process

### DIFF
--- a/main/CO2-read/C5-OTA-fast-1.4.cpp
+++ b/main/CO2-read/C5-OTA-fast-1.4.cpp
@@ -11,9 +11,6 @@
 #define EXTIO_LED_BLUE   (8+3)  // IO1_3 3 & 2 are swapped in schematics
 #define EXTIO_LED_GREEN  (8+2)  // IO1_2
 #define IO_BOOT_C5 GPIO_NUM_28
-// SENSOR ID (old API_KEY)
-char * nvs_sensor_id;
-size_t sensor_id_size;
 
 float firmware_version = 1.1;
 
@@ -521,7 +518,8 @@ static esp_err_t write_cb(const esp_rmaker_device_t *device, const esp_rmaker_pa
 bool check_firmware_update(char* update_url, size_t url_size)
 {
     char url[256];
-    snprintf(url, sizeof(url), "http://%s/api/firmware/C5/%s", WEB_HOST, nvs_sensor_id);
+    // Attention: Backend should validate this for C5 only using MAC and not anymore sensor_id
+    snprintf(url, sizeof(url), "http://%s/api/firmware/C5/%s", WEB_HOST, mac_string);
     
     ESP_LOGI(TAG, "Checking for firmware updates at: %s", url);
     
@@ -1114,7 +1112,7 @@ void send_data_to_api()
 
     printf("DATA: %s \nURL: %s\n", result.buf, API_URL);
     esp_http_client_handle_t client = esp_http_client_init(&config);
-
+    // Please set here the Authorisation: Bearer
     esp_http_client_set_header(client, "Content-Type", "application/json");
     esp_http_client_set_post_field(client, result.buf, strlen(result.buf));
     esp_err_t err = ESP_OK;
@@ -1186,9 +1184,6 @@ static void qr_draw_task(void *arg)
             continue;
         }
 
-        // Defensive: ensure strings exist
-        const char *id = (nvs_sensor_id) ? nvs_sensor_id : "NO_ID";
-
         const int size = g_qr.size;
         const int sq = 5;
         const int x_offset = EPD_WIDTH - 260;
@@ -1217,7 +1212,7 @@ static void qr_draw_task(void *arg)
         snprintf(textbuffer, sizeof(textbuffer), "%s", MESSAGE_SCAN_QR2);
         epaper->drawString(textbuffer, 430, 160);
 
-        snprintf(textbuffer, sizeof(textbuffer), "%s", id);
+        snprintf(textbuffer, sizeof(textbuffer), "MAC: %s", mac_string);
         epaper->drawString(textbuffer, 462, 310);
 
         snprintf(textbuffer, sizeof(textbuffer), "%s welcomes you!", WEB_HOST);
@@ -1600,7 +1595,8 @@ void build_request_json() {
         json_gen_obj_set_float(&jstr, "temperature", tem);
         json_gen_obj_set_float(&jstr, "humidity", hum);
         json_gen_push_object(&jstr, "client");
-        json_gen_obj_set_string(&jstr, "key", nvs_sensor_id);
+        // No more key here. Authentication: Bearer will be sent in the request
+        //json_gen_obj_set_string(&jstr, "key", nvs_sensor_id);
         json_gen_obj_set_string(&jstr, "rtc_t", rtc_time_str);
         json_gen_obj_set_string(&jstr, "model", "S3");
         json_gen_obj_set_float(&jstr, "version", firmware_version);
@@ -1876,10 +1872,6 @@ void app_main()
     {
         ESP_LOGE(TAG, "Error (%s) opening NVS handle!\n", esp_err_to_name(err));
     }
-    // Read stored SENSOR_ID
-    nvs_get_str(nvs_h, "sensor_id", NULL, &sensor_id_size);
-    nvs_sensor_id = (char*)malloc(sensor_id_size);
-    nvs_get_str(nvs_h, "sensor_id", nvs_sensor_id, &sensor_id_size);
 
     nvs_get_i16(nvs_h, "boots", &nvs_boots);
     ESP_LOGI(TAG, "-> NVS Boot count: %d", nvs_boots);
@@ -1887,14 +1879,7 @@ void app_main()
     // Set new value
     nvs_set_i16(nvs_h, "boots", nvs_boots);
     
-    if (strcmp(SENSOR_ID, "") == 0) {
-        printf("SENSOR_ID is empty reading it from NVS\n");
-    } else {
-        nvs_set_str(nvs_h, "sensor_id", SENSOR_ID);
-        strcpy(nvs_sensor_id, SENSOR_ID);
-    }
-    nvs_commit(nvs_h);
-    nvs_close(nvs_h);
+    // No more SENSOR ID let's use the MAC!
 
     // We read sensor here
     scd_read();

--- a/main/CO2-read/C5-OTA-fast-1.4.cpp
+++ b/main/CO2-read/C5-OTA-fast-1.4.cpp
@@ -934,7 +934,7 @@ void parse_json(const char* json_string)
  *
  * @param friendly_id Human-readable claim code returned by the backend.
  */
-void draw_claim_screen(const char* friendly_id)
+void draw_claim_screen(const char* friendly_id, uint16_t sleep_minutes)
 {
     epaper->fillScreen(0xF);
     epaper->setTextColor(0x0);
@@ -956,7 +956,8 @@ void draw_claim_screen(const char* friendly_id)
     char textbuffer[AUTH_HEADER_MAX_LEN];
     snprintf(textbuffer, sizeof(textbuffer), "MAC: %s", mac_string);
     epaper->drawString(textbuffer, 80, 370);
-    epaper->drawString("Checking again in 5 minutes...", 80, 430);
+    snprintf(textbuffer, sizeof(textbuffer), "Checking again in %u minutes...", sleep_minutes);
+    epaper->drawString(textbuffer, 80, 430);
 
     BB_RECT box{ .x = 0, .y = 0, .w = EPD_WIDTH, .h = EPD_HEIGHT };
     epaper->fullUpdate(true, false, &box);
@@ -1219,7 +1220,7 @@ void send_data_to_api()
         }
         ESP_LOGI(TAG, "Device not onboarded (HTTP %d). Claim ID: %s, retry in %d min",
                  status_code, res_friendly_id, nvs_minutes_till_refresh);
-        draw_claim_screen(res_friendly_id);
+        draw_claim_screen(res_friendly_id, nvs_minutes_till_refresh);
         schedule_rtc_wakeup_minutes(nvs_minutes_till_refresh);
     } else {
         // Normal onboarded response: render analytics.

--- a/main/CO2-read/C5-OTA-fast-1.4.cpp
+++ b/main/CO2-read/C5-OTA-fast-1.4.cpp
@@ -747,9 +747,10 @@ static void rv3032_force_int_enable()
 
 void parse_json(const char* json_string)
 {
-    // Always clear the claim flag first so callers get a clean state even
+    // Always clear these flags first so callers get a clean state even
     // when cJSON_Parse() fails (e.g. plain-text "Unauthorised" body).
     res_friendly_id[0] = '\0';
+    res_message[0] = '\0';
 
     // Parse the JSON string
     cJSON *root = cJSON_Parse(json_string);
@@ -1189,16 +1190,22 @@ void send_data_to_api()
     // or parse analytics fields if the device is already onboarded.
     parse_json(local_response_buffer);
 
-    // HTTP 401 means the MAC is not yet registered, regardless of body format.
-    // The body may be plain "Unauthorised" text or JSON with a friendly_id field.
-    if (status_code == 401 || res_friendly_id[0] != '\0') {
-        // If the 401 body did not contain a friendly_id, fall back to the MAC so
-        // the user still has a reference they can use to claim the device.
+    // Detect unregistered device in all the ways the backend can signal it:
+    //   1. Explicit HTTP 401
+    //   2. A friendly_id field in the response body (future backend behaviour)
+    //   3. HTTP 200 with {"message": "Unauthorized"/"Unauthorised"} (current backend behaviour)
+    bool claim_pending = (status_code == 401) ||
+                         (res_friendly_id[0] != '\0') ||
+                         (strncasecmp(res_message, "Unauthori", 9) == 0);
+
+    if (claim_pending) {
+        // If no friendly_id came from the body, use the MAC so the user has
+        // a reference they can type into sensoria.cat to claim the device.
         if (res_friendly_id[0] == '\0') {
             snprintf(res_friendly_id, sizeof(res_friendly_id), "%s", mac_string);
         }
-        ESP_LOGI(TAG, "Device not onboarded (HTTP %d). Showing claim screen with ID: %s",
-                 status_code, res_friendly_id);
+        ESP_LOGI(TAG, "Device not onboarded (HTTP %d, msg='%s'). Claim ID: %s",
+                 status_code, res_message, res_friendly_id);
         draw_claim_screen(res_friendly_id);
         nvs_minutes_till_refresh = 5;
         schedule_rtc_wakeup_minutes(5);

--- a/main/CO2-read/C5-OTA-fast-1.4.cpp
+++ b/main/CO2-read/C5-OTA-fast-1.4.cpp
@@ -747,6 +747,10 @@ static void rv3032_force_int_enable()
 
 void parse_json(const char* json_string)
 {
+    // Always clear the claim flag first so callers get a clean state even
+    // when cJSON_Parse() fails (e.g. plain-text "Unauthorised" body).
+    res_friendly_id[0] = '\0';
+
     // Parse the JSON string
     cJSON *root = cJSON_Parse(json_string);
     if (root == NULL) {
@@ -756,7 +760,6 @@ void parse_json(const char* json_string)
 
     // If the backend returns a friendly_id the device is not yet onboarded.
     // Store it and return early – the caller will handle the claim screen.
-    res_friendly_id[0] = '\0';
     cJSON *fid = cJSON_GetObjectItem(root, "friendly_id");
     if (cJSON_IsString(fid) && fid->valuestring != NULL) {
         snprintf(res_friendly_id, sizeof(res_friendly_id), "%s", fid->valuestring);
@@ -1170,9 +1173,11 @@ void send_data_to_api()
     esp_err_t err = ESP_OK;
 
     err = esp_http_client_perform(client);
+    int status_code = 0;
     if (err == ESP_OK)
     {
-        ESP_LOGI(TAG, "HTTP POST Status = %d", esp_http_client_get_status_code(client));
+        status_code = esp_http_client_get_status_code(client);
+        ESP_LOGI(TAG, "HTTP POST Status = %d", status_code);
     }
     else
     {
@@ -1180,12 +1185,20 @@ void send_data_to_api()
         schedule_rtc_wakeup_minutes(10);
     }
 
-    // parse_json() will set res_friendly_id if the device is not yet onboarded,
-    // or parse analytics fields and set the RTC alarm if it is.
+    // parse_json() will set res_friendly_id if the body contains a friendly_id field,
+    // or parse analytics fields if the device is already onboarded.
     parse_json(local_response_buffer);
 
-    if (res_friendly_id[0] != '\0') {
-        // Device not registered: show claim screen and come back in 5 minutes.
+    // HTTP 401 means the MAC is not yet registered, regardless of body format.
+    // The body may be plain "Unauthorised" text or JSON with a friendly_id field.
+    if (status_code == 401 || res_friendly_id[0] != '\0') {
+        // If the 401 body did not contain a friendly_id, fall back to the MAC so
+        // the user still has a reference they can use to claim the device.
+        if (res_friendly_id[0] == '\0') {
+            snprintf(res_friendly_id, sizeof(res_friendly_id), "%s", mac_string);
+        }
+        ESP_LOGI(TAG, "Device not onboarded (HTTP %d). Showing claim screen with ID: %s",
+                 status_code, res_friendly_id);
         draw_claim_screen(res_friendly_id);
         nvs_minutes_till_refresh = 5;
         schedule_rtc_wakeup_minutes(5);

--- a/main/CO2-read/C5-OTA-fast-1.4.cpp
+++ b/main/CO2-read/C5-OTA-fast-1.4.cpp
@@ -943,7 +943,11 @@ void draw_claim_screen(const char* friendly_id)
     epaper->drawString("Claim your device", 100, 80);
 
     epaper->setFont(ubuntu20);
-    epaper->drawString("Visit sensoria.cat and enter your device ID:", 80, 160);
+    char url[140];
+    // Attention: Backend should validate this for C5 only using MAC and not anymore sensor_id
+    snprintf(url, sizeof(url), "Visit %s/welcome and enter your device ID:", WEB_HOST);
+
+    epaper->drawString(url, 80, 160);
 
     epaper->setFont(ubuntu40);
     epaper->drawString(friendly_id, 200, 260);

--- a/main/CO2-read/C5-OTA-fast-1.4.cpp
+++ b/main/CO2-read/C5-OTA-fast-1.4.cpp
@@ -182,6 +182,8 @@ char* mac_string;
 #define FRIENDLY_ID_MAX_LEN 48
 // Authorization header value: "Bearer xx:xx:xx:xx:xx:xx" + null
 #define AUTH_HEADER_MAX_LEN 64
+// Default retry interval (minutes) when the backend does not supply sleep_minutes
+#define CLAIM_RETRY_MINUTES 10
 char res_friendly_id[FRIENDLY_ID_MAX_LEN] = {0};
 
 // EPD framebuffer
@@ -760,11 +762,19 @@ void parse_json(const char* json_string)
     }
 
     // If the backend returns a friendly_id the device is not yet onboarded.
-    // Store it and return early – the caller will handle the claim screen.
+    // Also read sleep_minutes so the backend can control the retry interval.
+    // Return early – the caller will handle the claim screen.
     cJSON *fid = cJSON_GetObjectItem(root, "friendly_id");
     if (cJSON_IsString(fid) && fid->valuestring != NULL) {
         snprintf(res_friendly_id, sizeof(res_friendly_id), "%s", fid->valuestring);
-        ESP_LOGI(TAG, "Device not onboarded yet. Friendly ID: %s", res_friendly_id);
+        cJSON *sm = cJSON_GetObjectItem(root, "sleep_minutes");
+        if (cJSON_IsNumber(sm) && sm->valueint > 0) {
+            nvs_minutes_till_refresh = sm->valueint;
+        } else {
+            nvs_minutes_till_refresh = CLAIM_RETRY_MINUTES; // sensible default if field is missing
+        }
+        ESP_LOGI(TAG, "Device not onboarded. Friendly ID: %s, sleep: %d min",
+                 res_friendly_id, nvs_minutes_till_refresh);
         cJSON_Delete(root);
         return;
     }
@@ -1190,25 +1200,23 @@ void send_data_to_api()
     // or parse analytics fields if the device is already onboarded.
     parse_json(local_response_buffer);
 
-    // Detect unregistered device in all the ways the backend can signal it:
-    //   1. Explicit HTTP 401
-    //   2. A friendly_id field in the response body (future backend behaviour)
-    //   3. HTTP 200 with {"message": "Unauthorized"/"Unauthorised"} (current backend behaviour)
-    bool claim_pending = (status_code == 401) ||
-                         (res_friendly_id[0] != '\0') ||
-                         (strncasecmp(res_message, "Unauthori", 9) == 0);
+    // Detect unregistered device. The backend now always sends a proper JSON
+    // with a friendly_id field. HTTP 401 is kept as a belt-and-braces guard.
+    bool claim_pending = (status_code == 401) || (res_friendly_id[0] != '\0');
 
     if (claim_pending) {
-        // If no friendly_id came from the body, use the MAC so the user has
-        // a reference they can type into sensoria.cat to claim the device.
+        // If somehow no friendly_id came from the body, use the MAC so the
+        // user still has a reference to enter at sensoria.cat.
         if (res_friendly_id[0] == '\0') {
             snprintf(res_friendly_id, sizeof(res_friendly_id), "%s", mac_string);
+            // nvs_minutes_till_refresh was already set by parse_json() from the
+            // backend's sleep_minutes field, or it holds the DEEP_SLEEP_MINUTES
+            // default – either is a reasonable retry interval.
         }
-        ESP_LOGI(TAG, "Device not onboarded (HTTP %d, msg='%s'). Claim ID: %s",
-                 status_code, res_message, res_friendly_id);
+        ESP_LOGI(TAG, "Device not onboarded (HTTP %d). Claim ID: %s, retry in %d min",
+                 status_code, res_friendly_id, nvs_minutes_till_refresh);
         draw_claim_screen(res_friendly_id);
-        nvs_minutes_till_refresh = 5;
-        schedule_rtc_wakeup_minutes(5);
+        schedule_rtc_wakeup_minutes(nvs_minutes_till_refresh);
     } else {
         // Normal onboarded response: render analytics.
         draw_response_analisis(res_tipo);

--- a/main/CO2-read/C5-OTA-fast-1.4.cpp
+++ b/main/CO2-read/C5-OTA-fast-1.4.cpp
@@ -178,6 +178,11 @@ char res_message[40];
 int16_t nvs_boots = 0;
 // Define the global MAC address variable
 char* mac_string;
+// Friendly ID returned by the backend when the device MAC is not yet onboarded
+#define FRIENDLY_ID_MAX_LEN 48
+// Authorization header value: "Bearer xx:xx:xx:xx:xx:xx" + null
+#define AUTH_HEADER_MAX_LEN 64
+char res_friendly_id[FRIENDLY_ID_MAX_LEN] = {0};
 
 // EPD framebuffer
 uint8_t *fb;
@@ -749,6 +754,17 @@ void parse_json(const char* json_string)
         return;
     }
 
+    // If the backend returns a friendly_id the device is not yet onboarded.
+    // Store it and return early – the caller will handle the claim screen.
+    res_friendly_id[0] = '\0';
+    cJSON *fid = cJSON_GetObjectItem(root, "friendly_id");
+    if (cJSON_IsString(fid) && fid->valuestring != NULL) {
+        snprintf(res_friendly_id, sizeof(res_friendly_id), "%s", fid->valuestring);
+        ESP_LOGI(TAG, "Device not onboarded yet. Friendly ID: %s", res_friendly_id);
+        cJSON_Delete(root);
+        return;
+    }
+
     // sleep_minutes: Get the integer value
     cJSON *sleep_minutes = cJSON_GetObjectItem(root, "sleep_minutes");
     cJSON *sensor_tipo = cJSON_GetObjectItem(root, "tipo");
@@ -894,6 +910,38 @@ void parse_json(const char* json_string)
     }
     printf("ALARM_TIME: %02d/%02d/%d %02d:%02d\n", aTime.tm_mday, aTime.tm_mon, aTime.tm_year, aTime.tm_hour, aTime.tm_min);
     rv3032_force_int_enable();
+}
+
+/**
+ * @brief Display the "Claim your device" screen showing the friendly_id.
+ *
+ * Called when the backend returns a friendly_id instead of sensor analytics,
+ * meaning the device MAC has not yet been onboarded.
+ *
+ * @param friendly_id Human-readable claim code returned by the backend.
+ */
+void draw_claim_screen(const char* friendly_id)
+{
+    epaper->fillScreen(0xF);
+    epaper->setTextColor(0x0);
+
+    epaper->setFont(ubuntu30);
+    epaper->drawString("Claim your device", 100, 80);
+
+    epaper->setFont(ubuntu20);
+    epaper->drawString("Visit sensoria.cat and enter your device ID:", 80, 160);
+
+    epaper->setFont(ubuntu40);
+    epaper->drawString(friendly_id, 200, 260);
+
+    epaper->setFont(ubuntu20);
+    char textbuffer[AUTH_HEADER_MAX_LEN];
+    snprintf(textbuffer, sizeof(textbuffer), "MAC: %s", mac_string);
+    epaper->drawString(textbuffer, 80, 370);
+    epaper->drawString("Checking again in 5 minutes...", 80, 430);
+
+    BB_RECT box{ .x = 0, .y = 0, .w = EPD_WIDTH, .h = EPD_HEIGHT };
+    epaper->fullUpdate(true, false, &box);
 }
 
 /**
@@ -1112,8 +1160,12 @@ void send_data_to_api()
 
     printf("DATA: %s \nURL: %s\n", result.buf, API_URL);
     esp_http_client_handle_t client = esp_http_client_init(&config);
-    // Please set here the Authorisation: Bearer
     esp_http_client_set_header(client, "Content-Type", "application/json");
+    // Authorisation: Bearer MAC_ADDRESS – used by backend to identify the device.
+    // If the MAC is not yet registered the backend returns a JSON with a friendly_id.
+    char auth_header[AUTH_HEADER_MAX_LEN];
+    snprintf(auth_header, sizeof(auth_header), "Bearer %s", mac_string);
+    esp_http_client_set_header(client, "Authorization", auth_header);
     esp_http_client_set_post_field(client, result.buf, strlen(result.buf));
     esp_err_t err = ESP_OK;
 
@@ -1128,10 +1180,19 @@ void send_data_to_api()
         schedule_rtc_wakeup_minutes(10);
     }
 
-    // Got a body - parse and draw
-    //ESP_LOG_BUFFER_CHAR(TAG, local_response_buffer, strlen(local_response_buffer));
+    // parse_json() will set res_friendly_id if the device is not yet onboarded,
+    // or parse analytics fields and set the RTC alarm if it is.
     parse_json(local_response_buffer);
-    draw_response_analisis(res_tipo);
+
+    if (res_friendly_id[0] != '\0') {
+        // Device not registered: show claim screen and come back in 5 minutes.
+        draw_claim_screen(res_friendly_id);
+        nvs_minutes_till_refresh = 5;
+        schedule_rtc_wakeup_minutes(5);
+    } else {
+        // Normal onboarded response: render analytics.
+        draw_response_analisis(res_tipo);
+    }
 
     // Clean up
     esp_http_client_cleanup(client);

--- a/main/config.h
+++ b/main/config.h
@@ -1,6 +1,7 @@
 // API CONFIG & General settings
 // Please apply for an API Key in sensoria.cat
-#define SENSOR_ID ""
+//#define SENSOR_ID ""
+// SENSOR_ID is deprecated. It will get the SENSOR defined in backend only using MAC address
 //#define MESSAGE_SCAN_QR1 "1. Baje el App ESP-Rainmaker"
 //#define MESSAGE_SCAN_QR2 "2. Escanee el QR-CODE"
 #define MESSAGE_SCAN_QR1 "1 Download ESP-Rainmaker app"


### PR DESCRIPTION
@copilot can you please implement this defined in Issue #8

The idea is that the device will log as usual but using an:

Authorisation: Bearer MAC_ADDRESS

And if that is not registered in our backend, will return a JSON containing a friendly_id. This has to be printed on the display. 
Every 5 minutes it will wake up and repeat the same process. When the Sensor ID is already onboarded then it should log using that authorisation Bearer.

This PR deprecates saving the sensor_id in NVS and keeps MAC as first thing to authorise a device. 