### PR TITLE
Checking Rainmaker events

### DIFF
--- a/main/CO2-read/C5-OTA-fast-1.4.cpp
+++ b/main/CO2-read/C5-OTA-fast-1.4.cpp
@@ -1343,7 +1343,9 @@ void esp_qrcode_print_eink(esp_qrcode_handle_t qrcode)
     }
 }
 
-/* Event handler for catching RainMaker events */
+/* Event handler for catching RainMaker events 
+copilot: Is there a way to detect a "Can't connect to WiFi event?" I don't see any that can be triggered here
+*/
 static void event_handler_rmk(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data)
 {
     if (event_base == RMAKER_EVENT) {

--- a/main/CO2-read/C5-OTA-fast-1.4.cpp
+++ b/main/CO2-read/C5-OTA-fast-1.4.cpp
@@ -120,6 +120,11 @@ uint16_t nvs_minutes_till_refresh = DEEP_SLEEP_MINUTES;
 }
 static TaskHandle_t qr_draw_task_handle = nullptr;
 
+/* Tracks how many times the already-provisioned STA has failed to connect since the
+ * last successful connection (or since boot).  Declared at file scope so that both
+ * the disconnect and connect branches of event_handler_rmk() can access it. */
+static int s_wifi_disconn_count = 0;
+
 static struct {
     int size;
     // max version you configured is 10 => max module size is 57.
@@ -1493,15 +1498,17 @@ static void event_handler_rmk(void* arg, esp_event_base_t event_base, int32_t ev
                 ESP_LOGW(TAG, "Unhandled OTA Event: %" PRIi32, event_id);
                 break;
         }
+    } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_CONNECTED) {
+        /* Reset the disconnect counter whenever a connection is established */
+        s_wifi_disconn_count = 0;
     } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
         /* Safe: all handlers registered via esp_event_handler_register() are called
          * sequentially from the single default-event-loop task. */
-        static int wifi_disconn_count = 0;
         static constexpr int kWifiFailSleepMin = 3;
-        wifi_disconn_count++;
-        ESP_LOGW(TAG, "Wi-Fi STA disconnected (attempt %d)", wifi_disconn_count);
+        s_wifi_disconn_count++;
+        ESP_LOGW(TAG, "Wi-Fi STA disconnected (attempt %d)", s_wifi_disconn_count);
 
-        if (wifi_disconn_count == 3) {
+        if (s_wifi_disconn_count == 3) {
             /* Show a message on the display so the user can see the problem */
             constexpr size_t kWifiSsidLen = sizeof(wifi_sta_config_t{}.ssid) + 1;
             wifi_config_t wifi_cfg = {};
@@ -1520,10 +1527,10 @@ static void event_handler_rmk(void* arg, esp_event_base_t event_base, int32_t ev
             epaper->drawString("Check SSID / password in ESP-RainMaker", 10, 230);
             epaper->drawString("Will retry every 3 min.", 10, 290);
             epaper->fullUpdate();
-        } else if (wifi_disconn_count >= 6) {
+        } else if (s_wifi_disconn_count >= 6) {
             /* Enough retries — sleep and try again after 3 minutes */
             ESP_LOGW(TAG, "Too many Wi-Fi failures. Going to deep sleep for 3 min.");
-            wifi_disconn_count = 0;
+            s_wifi_disconn_count = 0;
             schedule_rtc_wakeup_minutes(kWifiFailSleepMin);
             hold_pins_low_before_sleep();
             esp_deep_sleep(1000000LL * 60 * kWifiFailSleepMin);
@@ -2064,6 +2071,7 @@ void app_main()
     ESP_ERROR_CHECK(esp_event_handler_register(APP_NETWORK_EVENT, ESP_EVENT_ANY_ID, &event_handler_rmk, NULL));
     /* Register Wi-Fi STA disconnect events so we can show a display message when the AP is unreachable */
     ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, WIFI_EVENT_STA_DISCONNECTED, &event_handler_rmk, NULL));
+    ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, WIFI_EVENT_STA_CONNECTED,    &event_handler_rmk, NULL));
     /* Initialize the ESP RainMaker Agent.
      * Note that this should be called after app_network_init() but before app_network_start()
      * */

--- a/main/CO2-read/C5-OTA-fast-1.4.cpp
+++ b/main/CO2-read/C5-OTA-fast-1.4.cpp
@@ -1494,7 +1494,10 @@ static void event_handler_rmk(void* arg, esp_event_base_t event_base, int32_t ev
                 break;
         }
     } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
+        /* Safe: all handlers registered via esp_event_handler_register() are called
+         * sequentially from the single default-event-loop task. */
         static int wifi_disconn_count = 0;
+        static constexpr int kWifiFailSleepMin = 3;
         wifi_disconn_count++;
         ESP_LOGW(TAG, "Wi-Fi STA disconnected (attempt %d)", wifi_disconn_count);
 
@@ -1521,9 +1524,9 @@ static void event_handler_rmk(void* arg, esp_event_base_t event_base, int32_t ev
             /* Enough retries — sleep and try again after 3 minutes */
             ESP_LOGW(TAG, "Too many Wi-Fi failures. Going to deep sleep for 3 min.");
             wifi_disconn_count = 0;
-            schedule_rtc_wakeup_minutes(3);
+            schedule_rtc_wakeup_minutes(kWifiFailSleepMin);
             hold_pins_low_before_sleep();
-            esp_deep_sleep(1000000LL * 60 * 3);
+            esp_deep_sleep(1000000LL * 60 * kWifiFailSleepMin);
         }
     } else {
         ESP_LOGW(TAG, "Invalid event received!");

--- a/main/CO2-read/C5-OTA-fast-1.4.cpp
+++ b/main/CO2-read/C5-OTA-fast-1.4.cpp
@@ -1510,6 +1510,8 @@ static void event_handler_rmk(void* arg, esp_event_base_t event_base, int32_t ev
 
         if (s_wifi_disconn_count == 3) {
             /* Show a message on the display so the user can see the problem */
+            /* wifi_sta_config_t::ssid is 32 bytes without a guaranteed null terminator,
+             * so the display buffer is 33 bytes (32 + null) and we null-terminate explicitly. */
             constexpr size_t kWifiSsidLen = sizeof(wifi_sta_config_t{}.ssid) + 1;
             wifi_config_t wifi_cfg = {};
             char ssid_text[kWifiSsidLen] = {0};
@@ -1524,16 +1526,17 @@ static void event_handler_rmk(void* arg, esp_event_base_t event_base, int32_t ev
             if (ssid_text[0] != '\0') {
                 epaper->drawString(ssid_text, 10, 170);
             }
-            epaper->drawString("Check SSID / password in ESP-RainMaker", 10, 230);
+            epaper->drawString("Check Wi-Fi credentials in ESP-RainMaker", 10, 230);
             epaper->drawString("Will retry every 3 min.", 10, 290);
             epaper->fullUpdate();
         } else if (s_wifi_disconn_count >= 6) {
             /* Enough retries — sleep and try again after 3 minutes */
+            constexpr uint64_t kUsPerSecond = 1000000ULL;
             ESP_LOGW(TAG, "Too many Wi-Fi failures. Going to deep sleep for 3 min.");
             s_wifi_disconn_count = 0;
             schedule_rtc_wakeup_minutes(kWifiFailSleepMin);
             hold_pins_low_before_sleep();
-            esp_deep_sleep(1000000LL * 60 * kWifiFailSleepMin);
+            esp_deep_sleep(kUsPerSecond * 60 * kWifiFailSleepMin);
         }
     } else {
         ESP_LOGW(TAG, "Invalid event received!");

--- a/main/CO2-read/C5-OTA-fast-1.4.cpp
+++ b/main/CO2-read/C5-OTA-fast-1.4.cpp
@@ -1527,7 +1527,7 @@ static void event_handler_rmk(void* arg, esp_event_base_t event_base, int32_t ev
                 epaper->drawString(ssid_text, 10, 170);
             }
             epaper->drawString("Check Wi-Fi credentials in ESP-RainMaker", 10, 230);
-            epaper->drawString("Will retry every 3 min.", 10, 290);
+            epaper->drawString("Will retry every 3 minutes.", 10, 290);
             epaper->fullUpdate();
         } else if (s_wifi_disconn_count >= 6) {
             /* Enough retries — sleep and try again after 3 minutes */

--- a/main/CO2-read/C5-OTA-fast-1.4.cpp
+++ b/main/CO2-read/C5-OTA-fast-1.4.cpp
@@ -1446,14 +1446,13 @@ static void event_handler_rmk(void* arg, esp_event_base_t event_base, int32_t ev
                      ESP_LOGW("NETWORK_EVENT", "Can't connect to Wi-Fi AP");
                  }
 
-                 epaper->fillRect(0, 80, EPD_WIDTH, 400, 0x0);
                  epaper->fillRect(0, 80, EPD_WIDTH, 400, 0xF);
                  epaper->drawString("Can't connect to Wi-Fi AP", 10, 110);
                  if (ssid_text[0] != '\0') {
                      epaper->drawString(ssid_text, 10, 170);
                  }
                  epaper->drawString("Check SSID/password in ESP-RainMaker", 10, 230);
-                 epaper->drawString("Provisioning will restart automatically", 10, 290);
+                 epaper->drawString("RainMaker provisioning will retry", 10, 290);
                  epaper->fullUpdate();
                  vTaskDelay(pdMS_TO_TICKS(500));
                  break;

--- a/main/CO2-read/C5-OTA-fast-1.4.cpp
+++ b/main/CO2-read/C5-OTA-fast-1.4.cpp
@@ -1493,6 +1493,38 @@ static void event_handler_rmk(void* arg, esp_event_base_t event_base, int32_t ev
                 ESP_LOGW(TAG, "Unhandled OTA Event: %" PRIi32, event_id);
                 break;
         }
+    } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
+        static int wifi_disconn_count = 0;
+        wifi_disconn_count++;
+        ESP_LOGW(TAG, "Wi-Fi STA disconnected (attempt %d)", wifi_disconn_count);
+
+        if (wifi_disconn_count == 3) {
+            /* Show a message on the display so the user can see the problem */
+            constexpr size_t kWifiSsidLen = sizeof(wifi_sta_config_t{}.ssid) + 1;
+            wifi_config_t wifi_cfg = {};
+            char ssid_text[kWifiSsidLen] = {0};
+            if (esp_wifi_get_config(WIFI_IF_STA, &wifi_cfg) == ESP_OK && wifi_cfg.sta.ssid[0] != '\0') {
+                memcpy(ssid_text, wifi_cfg.sta.ssid, sizeof(wifi_cfg.sta.ssid));
+                ssid_text[kWifiSsidLen - 1] = '\0';
+                ESP_LOGW(TAG, "Can't connect to Wi-Fi AP: %s", ssid_text);
+            }
+            status_led_off();
+            epaper->fillRect(0, 80, EPD_WIDTH, 400, 0xF);
+            epaper->drawString("Can't connect to Wi-Fi AP", 10, 110);
+            if (ssid_text[0] != '\0') {
+                epaper->drawString(ssid_text, 10, 170);
+            }
+            epaper->drawString("Check SSID / password in ESP-RainMaker", 10, 230);
+            epaper->drawString("Will retry every 3 min.", 10, 290);
+            epaper->fullUpdate();
+        } else if (wifi_disconn_count >= 6) {
+            /* Enough retries — sleep and try again after 3 minutes */
+            ESP_LOGW(TAG, "Too many Wi-Fi failures. Going to deep sleep for 3 min.");
+            wifi_disconn_count = 0;
+            schedule_rtc_wakeup_minutes(3);
+            hold_pins_low_before_sleep();
+            esp_deep_sleep(1000000LL * 60 * 3);
+        }
     } else {
         ESP_LOGW(TAG, "Invalid event received!");
     }
@@ -2027,6 +2059,8 @@ void app_main()
     /* Register an event handler to catch RainMaker events */
     ESP_ERROR_CHECK(esp_event_handler_register(RMAKER_COMMON_EVENT, ESP_EVENT_ANY_ID, &event_handler_rmk, NULL));
     ESP_ERROR_CHECK(esp_event_handler_register(APP_NETWORK_EVENT, ESP_EVENT_ANY_ID, &event_handler_rmk, NULL));
+    /* Register Wi-Fi STA disconnect events so we can show a display message when the AP is unreachable */
+    ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, WIFI_EVENT_STA_DISCONNECTED, &event_handler_rmk, NULL));
     /* Initialize the ESP RainMaker Agent.
      * Note that this should be called after app_network_init() but before app_network_start()
      * */

--- a/main/CO2-read/C5-OTA-fast-1.4.cpp
+++ b/main/CO2-read/C5-OTA-fast-1.4.cpp
@@ -1434,14 +1434,14 @@ static void event_handler_rmk(void* arg, esp_event_base_t event_base, int32_t ev
                   break;
              }
             case APP_NETWORK_EVENT_PROV_RESTART: {
-                 constexpr size_t kWifiSsidTextSize = 33;
+                 constexpr size_t kWifiSsidTextSize = sizeof(wifi_sta_config_t{}.ssid) + 1;
                  wifi_config_t wifi_cfg = {};
                  char ssid_text[kWifiSsidTextSize] = {0};
                  esp_err_t wifi_err = esp_wifi_get_config(WIFI_IF_STA, &wifi_cfg);
 
                  status_led_off();
                  if (wifi_err == ESP_OK && wifi_cfg.sta.ssid[0] != '\0') {
-                     memcpy(ssid_text, wifi_cfg.sta.ssid, sizeof(wifi_cfg.sta.ssid));
+                     memcpy(ssid_text, wifi_cfg.sta.ssid, kWifiSsidTextSize - 1);
                      ssid_text[kWifiSsidTextSize - 1] = '\0';
                      ESP_LOGW("NETWORK_EVENT", "Can't connect to Wi-Fi AP: %s", ssid_text);
                  } else {

--- a/main/CO2-read/C5-OTA-fast-1.4.cpp
+++ b/main/CO2-read/C5-OTA-fast-1.4.cpp
@@ -1442,6 +1442,7 @@ static void event_handler_rmk(void* arg, esp_event_base_t event_base, int32_t ev
                  status_led_off();
                  if (wifi_err == ESP_OK && wifi_cfg.sta.ssid[0] != '\0') {
                      memcpy(ssid_text, wifi_cfg.sta.ssid, sizeof(wifi_cfg.sta.ssid));
+                     ssid_text[kWifiSsidTextSize - 1] = '\0';
                      ESP_LOGW("NETWORK_EVENT", "Can't connect to Wi-Fi AP: %s", ssid_text);
                  } else {
                      ESP_LOGW("NETWORK_EVENT", "Can't connect to Wi-Fi AP");
@@ -1457,11 +1458,11 @@ static void event_handler_rmk(void* arg, esp_event_base_t event_base, int32_t ev
                  epaper->fullUpdate();
                  vTaskDelay(pdMS_TO_TICKS(500));
                  break;
-             }
-             default:
-                 ESP_LOGW("NETWORK_EVENT", "Unhandled App Wi-Fi Event: %" PRIi32, event_id);
-                 break;
-         }
+            }
+            default:
+                ESP_LOGW("NETWORK_EVENT", "Unhandled App Wi-Fi Event: %" PRIi32, event_id);
+                break;
+        }
     } else if (event_base == RMAKER_OTA_EVENT) {
         switch(event_id) {
             case RMAKER_OTA_EVENT_STARTING:

--- a/main/CO2-read/C5-OTA-fast-1.4.cpp
+++ b/main/CO2-read/C5-OTA-fast-1.4.cpp
@@ -1441,7 +1441,7 @@ static void event_handler_rmk(void* arg, esp_event_base_t event_base, int32_t ev
 
                  status_led_off();
                  if (wifi_err == ESP_OK && wifi_cfg.sta.ssid[0] != '\0') {
-                     memcpy(ssid_text, wifi_cfg.sta.ssid, kWifiSsidTextSize - 1);
+                     memcpy(ssid_text, wifi_cfg.sta.ssid, sizeof(wifi_cfg.sta.ssid));
                      ssid_text[kWifiSsidTextSize - 1] = '\0';
                      ESP_LOGW("NETWORK_EVENT", "Can't connect to Wi-Fi AP: %s", ssid_text);
                  } else {

--- a/main/CO2-read/C5-OTA-fast-1.4.cpp
+++ b/main/CO2-read/C5-OTA-fast-1.4.cpp
@@ -1504,7 +1504,7 @@ static void event_handler_rmk(void* arg, esp_event_base_t event_base, int32_t ev
     } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
         /* Safe: all handlers registered via esp_event_handler_register() are called
          * sequentially from the single default-event-loop task. */
-        static constexpr int kWifiFailSleepMin = 3;
+        static constexpr int kWifiFailSleepMin = 5;
         s_wifi_disconn_count++;
         ESP_LOGW(TAG, "Wi-Fi STA disconnected (attempt %d)", s_wifi_disconn_count);
 
@@ -1522,17 +1522,17 @@ static void event_handler_rmk(void* arg, esp_event_base_t event_base, int32_t ev
             }
             status_led_off();
             epaper->fillRect(0, 80, EPD_WIDTH, 400, 0xF);
-            epaper->drawString("Can't connect to Wi-Fi AP", 10, 110);
+            epaper->drawString("Can't connect to Wi-Fi", 20, 130);
             if (ssid_text[0] != '\0') {
-                epaper->drawString(ssid_text, 10, 170);
+                epaper->drawString(ssid_text, 20, 190);
             }
-            epaper->drawString("Check Wi-Fi credentials in ESP-RainMaker", 10, 230);
-            epaper->drawString("Will retry every 3 minutes.", 10, 290);
+            epaper->drawString("Click RST and keep BOOT pressed", 20, 250);
+            epaper->drawString("To clear WiFi credentials and connect again", 20, 310);
             epaper->fullUpdate();
         } else if (s_wifi_disconn_count >= 6) {
             /* Enough retries — sleep and try again after 3 minutes */
             constexpr uint64_t kUsPerSecond = 1000000ULL;
-            ESP_LOGW(TAG, "Too many Wi-Fi failures. Going to deep sleep for 3 min.");
+            ESP_LOGW(TAG, "Too many Wi-Fi failures. Going to deep sleep for 5 min.");
             s_wifi_disconn_count = 0;
             schedule_rtc_wakeup_minutes(kWifiFailSleepMin);
             hold_pins_low_before_sleep();

--- a/main/CO2-read/C5-OTA-fast-1.4.cpp
+++ b/main/CO2-read/C5-OTA-fast-1.4.cpp
@@ -97,6 +97,7 @@ uint16_t nvs_minutes_till_refresh = DEEP_SLEEP_MINUTES;
 #include "esp_tls.h"
 #include "esp_netif.h"
 #include "esp_http_client.h"
+#include "esp_wifi.h"
 
 // OTA
 #include "esp_ota_ops.h"
@@ -1343,9 +1344,7 @@ void esp_qrcode_print_eink(esp_qrcode_handle_t qrcode)
     }
 }
 
-/* Event handler for catching RainMaker events 
-copilot: Is there a way to detect a "Can't connect to WiFi event?" I don't see any that can be triggered here
-*/
+/* Event handler for catching RainMaker events */
 static void event_handler_rmk(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data)
 {
     if (event_base == RMAKER_EVENT) {
@@ -1429,15 +1428,40 @@ static void event_handler_rmk(void* arg, esp_event_base_t event_base, int32_t ev
                  epaper->drawString("Provisioning timed-out.", 10, 110);
                  epaper->drawString("< Press RESET and connect your device to USB-C", 10, 330);
                  epaper->drawString("The LED signal should be BLUE when it's ready >", 300, 490);
+                  epaper->fullUpdate();
+                  vTaskDelay(pdMS_TO_TICKS(500));
+                  schedule_rtc_wakeup_minutes(3);
+                  break;
+             }
+            case APP_NETWORK_EVENT_PROV_RESTART: {
+                 wifi_config_t wifi_cfg = {};
+                 char ssid_text[sizeof(wifi_cfg.sta.ssid) + 1] = {0};
+                 esp_err_t wifi_err = esp_wifi_get_config(WIFI_IF_STA, &wifi_cfg);
+
+                 status_led_off();
+                 if (wifi_err == ESP_OK && wifi_cfg.sta.ssid[0] != '\0') {
+                     memcpy(ssid_text, wifi_cfg.sta.ssid, sizeof(wifi_cfg.sta.ssid));
+                     ESP_LOGW("NETWORK_EVENT", "Can't connect to Wi-Fi AP: %s", ssid_text);
+                 } else {
+                     ESP_LOGW("NETWORK_EVENT", "Can't connect to Wi-Fi AP");
+                 }
+
+                 epaper->fillRect(0, 80, EPD_WIDTH, 400, 0x0);
+                 epaper->fillRect(0, 80, EPD_WIDTH, 400, 0xF);
+                 epaper->drawString("Can't connect to Wi-Fi AP", 10, 110);
+                 if (ssid_text[0] != '\0') {
+                     epaper->drawString(ssid_text, 10, 170);
+                 }
+                 epaper->drawString("Check SSID/password in ESP-RainMaker", 10, 230);
+                 epaper->drawString("Provisioning will restart automatically", 10, 290);
                  epaper->fullUpdate();
                  vTaskDelay(pdMS_TO_TICKS(500));
-                 schedule_rtc_wakeup_minutes(3);
                  break;
-            }
-            default:
-                ESP_LOGW("NETWORK_EVENT", "Unhandled App Wi-Fi Event: %" PRIi32, event_id);
-                break;
-        }
+             }
+             default:
+                 ESP_LOGW("NETWORK_EVENT", "Unhandled App Wi-Fi Event: %" PRIi32, event_id);
+                 break;
+         }
     } else if (event_base == RMAKER_OTA_EVENT) {
         switch(event_id) {
             case RMAKER_OTA_EVENT_STARTING:
@@ -2099,4 +2123,3 @@ void app_main()
     send_data_to_api();
     deep_sleep();
 }
-

--- a/main/CO2-read/C5-OTA-fast-1.4.cpp
+++ b/main/CO2-read/C5-OTA-fast-1.4.cpp
@@ -1434,8 +1434,9 @@ static void event_handler_rmk(void* arg, esp_event_base_t event_base, int32_t ev
                   break;
              }
             case APP_NETWORK_EVENT_PROV_RESTART: {
+                 constexpr size_t kWifiSsidTextSize = 33;
                  wifi_config_t wifi_cfg = {};
-                 char ssid_text[sizeof(wifi_cfg.sta.ssid) + 1] = {0};
+                 char ssid_text[kWifiSsidTextSize] = {0};
                  esp_err_t wifi_err = esp_wifi_get_config(WIFI_IF_STA, &wifi_cfg);
 
                  status_led_off();


### PR DESCRIPTION
I've checked and don't see that any existing event matches that in order to print something on the display. 

Failing to do so, if the WiFi is disconnected, or the device carried out of coverage zone then it can remain in a try to connect LOOP state.